### PR TITLE
chore: add Claude context files and secrets template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ out/
 # Cursor
 .cursor/
 
+# Claude
+.claude/
+
 # OS
 .DS_Store
 Thumbs.db
@@ -31,3 +34,6 @@ logs/
 
 # Local config overrides
 local.properties
+
+# Secrets
+secrets.json

--- a/secrets.json.example
+++ b/secrets.json.example
@@ -1,0 +1,91 @@
+{
+  "version": "1.0.0",
+  "shared": {
+    "supabase": {
+      "url": "",
+      "anon_key": "",
+      "service_role_key": "",
+      "database_url": ""
+    }
+  },
+  "projects": {
+    "asyncanticheat": {
+      "api": {
+        "dev": {
+          "host": "0.0.0.0",
+          "port": 3002,
+          "ingest_token": "",
+          "database_url": "",
+          "object_store": {
+            "type": "local",
+            "dir": "./data/object_store"
+          }
+        },
+        "prod": {
+          "host": "0.0.0.0",
+          "port": 3002,
+          "ingest_token": "",
+          "database_url": "",
+          "object_store": {
+            "type": "s3",
+            "bucket": "",
+            "region": ""
+          }
+        }
+      },
+      "website": {
+        "dev_user": {
+          "email": "",
+          "id": "",
+          "pass": ""
+        }
+      }
+    }
+  },
+  "servers": {
+    "dedicated": {
+      "ssh": {
+        "host": "",
+        "user": "root",
+        "port": 22,
+        "identity_file": "~/.ssh/id_rsa"
+      },
+      "systemd": {
+        "services": {
+          "asyncanticheat_api": "async-anticheat-api.service",
+          "movement_core": "async-anticheat-movement-core.service",
+          "movement_advanced": "async-anticheat-movement-advanced.service",
+          "combat_core": "async-anticheat-combat-core.service",
+          "combat_advanced": "async-anticheat-combat-advanced.service",
+          "player_core": "async-anticheat-player-core.service",
+          "player_advanced": "async-anticheat-player-advanced.service"
+        }
+      }
+    },
+    "test_server": {
+      "ssh": {
+        "host": "",
+        "user": "root",
+        "port": 22
+      },
+      "paths": {
+        "root_dir": "/root/minecraft/paper-1.21",
+        "plugins_dir": "/root/minecraft/paper-1.21/plugins"
+      },
+      "paper": {
+        "jar_path": "/root/minecraft/paper-1.21/paper.jar",
+        "project": "paper",
+        "version": "1.21.4",
+        "build": ""
+      },
+      "rcon": {
+        "host": "",
+        "port": 25575,
+        "password": ""
+      },
+      "systemd": {
+        "unit": "minecraft-test.service"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Added Claude context files for AI-assisted development and a secrets.json template for local configuration.

- `.claude/CLAUDE.md` - Project documentation, tech stack, build commands, key classes
- `.claude/settings.json` - Tool permission configuration 
- `secrets.json.example` - Template for deployment and server configuration
- Updated `.gitignore` to exclude `.claude/` and `secrets.json`

These files support local development workflows and AI agent integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a standardized secrets template and tightens repo hygiene.
> 
> - Adds `secrets.json.example` with structured config for `supabase`, `projects.asyncanticheat` (API dev/prod, website dev user), and `servers` (dedicated/test) including SSH, systemd services, paths, Paper, and RCON
> - Updates `.gitignore` to exclude `secrets.json` and the Claude context directory `.claude/`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7fdea0c9aaa6a9b1759853ec27b45a4cf6d67f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->