### PR TITLE
docs: add server_address and CORS config options

### DIFF
--- a/web/content/configuration.mdx
+++ b/web/content/configuration.mdx
@@ -18,6 +18,7 @@ api:
   url: "https://api.asyncanticheat.com"
   token: "your_api_token"
   timeout_seconds: 10
+  server_address: ""  # Optional: e.g., "play.myserver.com:25565"
 ```
 
 | Option | Description | Default |
@@ -25,6 +26,9 @@ api:
 | `url` | Base URL of your AsyncAnticheat API | Required |
 | `token` | Authentication token for API requests | Required |
 | `timeout_seconds` | Request timeout in seconds | `10` |
+| `server_address` | Server address for dashboard ping (auto-detected if empty) | `""` |
+
+> **Note:** The `server_address` is automatically detected from your server's IP when the plugin connects to the API. Only set this manually if auto-detection doesn't work (e.g., behind NAT or using a different public address).
 
 ### Spool Settings
 
@@ -127,7 +131,13 @@ OBJECT_STORE_CLEANUP_DRY_RUN="true"
 OBJECT_STORE_CLEANUP_INTERVAL_SECONDS="3600"
 OBJECT_STORE_TTL_DAYS="7"
 BATCH_INDEX_TTL_DAYS="7"
+
+# CORS
+CORS_ALLOW_ORIGINS="https://asyncanticheat.com,https://dashboard.asyncanticheat.com"
+CORS_PERMISSIVE_DEV="false"  # Only set true for local development
 ```
+
+> **Security Note:** `CORS_PERMISSIVE_DEV` must be explicitly set to `true` to enable permissive CORS. This prevents accidental exposure in production. For production, always use `CORS_ALLOW_ORIGINS` to specify allowed domains.
 
 ## Server-Specific Configuration
 


### PR DESCRIPTION
## Summary

Add documentation for new configuration options introduced in v0.3.0:

- **Plugin `server_address`**: Optional override for dashboard ping auto-detection
- **API `CORS_ALLOW_ORIGINS`**: Specify allowed origins for cross-origin requests
- **API `CORS_PERMISSIVE_DEV`**: Explicit opt-in for permissive CORS (dev only)

## Test Plan

- [x] Documentation renders correctly in Nextra

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `configuration.mdx` to cover new config options.
> 
> - Adds `api.server_address` to plugin settings (table entry + note explaining auto-detection and when to override)
> - Documents API CORS variables: `CORS_ALLOW_ORIGINS` and `CORS_PERMISSIVE_DEV`, including a security note requiring explicit enablement for permissive CORS
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b429079a259c87812fcff02a6f44e4b0a8209a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->