### PR TITLE
fix: correct FailurePolicy for Hopper dependency fallback chain

### DIFF
--- a/plugin/bukkit/src/main/java/md/thomas/asyncanticheat/bukkit/AacHopper.java
+++ b/plugin/bukkit/src/main/java/md/thomas/asyncanticheat/bukkit/AacHopper.java
@@ -53,20 +53,22 @@ public final class AacHopper {
 
             if (!hasPacketEvents) {
                 // Primary source: Modrinth (auto-detects platform)
+                // Use WARN_SKIP to allow fallback to GitHub if Modrinth fails
                 deps.require(Dependency.modrinth("packetevents")
                     .name("PacketEvents")
                     .minVersion("2.7.0")
                     .updatePolicy(UpdatePolicy.MINOR)
-                    .onFailure(FailurePolicy.FAIL)
+                    .onFailure(FailurePolicy.WARN_SKIP)
                     .build());
 
                 // Fallback source: GitHub releases
+                // Use FAIL since this is the last resort - PacketEvents is required
                 deps.require(Dependency.github("retrooper/packetevents")
                     .name("PacketEvents")
                     .minVersion("2.7.0")
                     .assetPattern("*-spigot-*.jar")
                     .updatePolicy(UpdatePolicy.MINOR)
-                    .onFailure(FailurePolicy.WARN_SKIP)
+                    .onFailure(FailurePolicy.FAIL)
                     .build());
             }
         });


### PR DESCRIPTION
## Summary
- Changed Modrinth `FailurePolicy` from `FAIL` to `WARN_SKIP` (allows fallback to GitHub on failure)
- Changed GitHub `FailurePolicy` from `WARN_SKIP` to `FAIL` (last resort - PacketEvents is required)

This ensures the fallback chain works correctly: if Modrinth fails → warn and try GitHub → if GitHub fails → fail (since PacketEvents is required).

## Test plan
- [ ] Verify plugin downloads PacketEvents from Modrinth when available
- [ ] Block Modrinth and verify fallback to GitHub works
- [ ] Block both sources and verify proper failure message

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns dependency fallback behavior for PacketEvents in `AacHopper.java`.
> 
> - Modrinth source now uses `onFailure(FailurePolicy.WARN_SKIP)` to enable fallback to GitHub
> - GitHub fallback now uses `onFailure(FailurePolicy.FAIL)` since PacketEvents is required
> - No other logic changed; applies only to dependency registration in `register(...)`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c55bd31ee113a1a7be21f114510497334943bda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->