### PR TITLE
feat: add Google Analytics tracking

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { Head } from "nextra/components";
 import { ThemeProvider } from "@/components/theme-provider";
 import { PWAInstallBanner } from "@/components/pwa/install-banner";
+import { GoogleAnalytics } from "@/components/google-analytics";
 import { Cinzel, Cormorant_Garamond } from "next/font/google";
 import "./globals.css";
 
@@ -68,6 +69,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" dir="ltr" suppressHydrationWarning>
+      <GoogleAnalytics />
       <Head>
         <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
         <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />

--- a/web/components/google-analytics.tsx
+++ b/web/components/google-analytics.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Script from "next/script";
+
+export function GoogleAnalytics() {
+  const gaId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+
+  if (!gaId) {
+    return null;
+  }
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+        strategy="afterInteractive"
+      />
+      <Script
+        id="google-analytics"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${gaId}');`,
+        }}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Add GoogleAnalytics client component using Next.js Script with dangerouslySetInnerHTML for hydration-safe inline script
- Add component to root layout
- Environment variable `NEXT_PUBLIC_GA_MEASUREMENT_ID` already added to Vercel for production and preview

## Test plan
- [ ] After merge, verify window.gtag is defined in browser console on asyncanticheat.com
- [ ] Verify dataLayer contains the config event

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Google Analytics loading and initialization.
> 
> - New client component `components/google-analytics.tsx` uses Next.js `Script` to load `gtag` and inline init; no-op if `NEXT_PUBLIC_GA_MEASUREMENT_ID` is missing
> - Integrates `GoogleAnalytics` in `app/layout.tsx` so tracking scripts load on all pages
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2405d2303101866518677f10431462f4d4c244ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->