### PR TITLE
Replace documentation link with Discord in header

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -114,10 +114,10 @@ export default function HomePage() {
               GitHub
             </Link>
             <Link
-              href="/docs"
+              href="https://discord.gg/2ng6q3JNQ7"
               className="text-xs font-medium text-[rgb(var(--foreground-secondary))] hover:text-[rgb(var(--foreground))] transition-colors"
             >
-              Documentation
+              Discord
             </Link>
             <Link
               href="/dashboard"
@@ -162,11 +162,11 @@ export default function HomePage() {
                 GitHub
               </Link>
               <Link
-                href="/docs"
+                href="https://discord.gg/2ng6q3JNQ7"
                 className="flex items-center gap-2 px-3 py-2.5 rounded-md text-sm font-medium text-[rgb(var(--foreground-secondary))] hover:text-[rgb(var(--foreground))] hover:bg-[rgb(var(--foreground))]/5 transition-colors"
                 onClick={() => setMobileMenuOpen(false)}
               >
-                Documentation
+                Discord
               </Link>
               <Link
                 href="/dashboard"


### PR DESCRIPTION
Replaces the Documentation link in the middle of the header with a Discord community link. The docs button remains on the right side of the header for easy access.

- Desktop nav: Changed Documentation link to Discord (https://discord.gg/2ng6q3JNQ7)
- Mobile nav: Changed Documentation link to Discord
- View Docs button: Unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates navigation to prioritize community access via Discord.
> 
> - Replaces `Documentation` link with `https://discord.gg/2ng6q3JNQ7` in desktop and mobile navs in `web/app/page.tsx`
> - Keeps `View Docs` button pointing to `/docs` unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8fec644b2a1f5312072018a25d294d51fe72176. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->